### PR TITLE
Add Day.js package to library comparison playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ various libraries.
 * moment.js
 * Luxon
 * date-fns-tz
+* Day.js
 
 ```bash
 yarn install
@@ -30,3 +31,117 @@ possible situation (eg, formatDistance, eachHourOfInterval, areIntervalsOverlapp
 However, its functional nature means that you have to import both `date-fns` and `date-fns-tz`,
 import each helper you intend to use, and there is no prebuilt package for standard web use; it must
 be packaged in your app. Full size is about 70k, but because it's functional, it's very shakable.
+
+## Overview
+
+### Moment.js
+
+A legacy project, now in maintenance mode. In most cases, a different solution should be chosen.
+
+> One day soon, we hope there won't be a strong need for date and time libraries in JavaScript at all. Instead, we will be able to use capabilities of the JavaScript language itself. Though some capabilities are here today, we know from experience and data that there is significant room for improvement.
+>
+> `Temporal` will be a new global object that acts as a top-level namespace (like `Math`). It exposes many separate types of objects including `Temporal.Instant`, `Temporal.ZonedDateTime`, `Temporal.PlainDate` and several others.
+
+We now generally consider Moment to be a legacy project in maintenance mode. It is not dead, but it is indeed done.
+
+### Luxon
+
+A powerful, modern, and friendly wrapper for JavaScript dates and times.
+
+```js
+// Now
+DateTime.now();
+
+// Parse From ISO
+DateTime.fromISO('2021-07-01T01:00:00.000Z');
+
+// Parse From MySQL
+DateTime.fromSQL('2021-07-01 01:00:00');
+
+// Query
+var d1 = DateTime.fromISO('2017-04-30');
+var d2 = DateTime.fromISO('2017-04-01');
+
+d2 < d1;
+
+// Display
+DateTime.now().toLocaleString(DateTime.DATE_FULL);
+
+// Manipulate + Relative Date
+DateTime.now().minus({ days: 2 }).toRelative();
+
+// Time Zone Support
+DateTime.fromISO('2014-06-25T10:00:00').setZone('America/New_York').toISO();
+```
+
+### Date Functions
+
+**date-fns** provides the most comprehensive, yet simple and consistent toolset
+for manipulating JavaScript dates in a browser & Node.js — _it's like Lodash for dates!_
+
+```js
+// Now
+format(Date.now(), "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"));
+
+// Parse From ISO
+parseISO('2021-07-01T01:00:00.000Z');
+
+// Parse From MySQL
+format('2021-07-01 01:00:00', 'YYYY-MM-DD HH-mm-ss');
+
+// Display
+format(new Date(), 'LLLL d, yyyy');
+
+// Query
+isAfter(new Date(1989, 6, 10), new Date(1987, 1, 11));
+
+// Manipulate + Relative Date
+formatDistance(subDays(new Date(), 3), new Date(), { addSuffix: true });
+
+// Time Zone Support
+zonedTimeToUtc('2014-06-25T10:00:00', 'America/New_York').toISOString();
+```
+
+### Day.js
+
+Day.js is a minimalist JavaScript library that parses, validates, manipulates, and displays dates and times for modern browsers with a largely Moment.js-compatible API. _If you use Moment.js, you already know how to use Day.js!_
+
+```js
+// Now
+dayjs();
+
+// Parse From ISO
+dayjs('2021-07-01T01:00:00.000Z');
+
+// Parse From MySQL
+dayjs.extend(customParseFormat);
+
+dayjs('2021-07-01 01:00:00', 'YYYY-MM-DD HH:mm:ss');
+
+// Display
+dayjs().format('MMMM D, YYYY')
+
+// Query
+dayjs().isBefore(dayjs('2021-07-01'));
+
+// Manipulate + Relative Date
+dayjs().subtract({ days: 2 }).fromNow();
+
+// Time Zone Support
+dayjs('2014-06-25T10:00').tz('America/New_York').format();
+```
+
+## Comparison
+
+| Project        | Unpacked | Transfer | GitHub Stars | Weekly Downloads | Version           |
+| -------------- | -------- | -------- | ------------ | ---------------- | ----------------- |
+| [Moment.js][1] | 4.21 MB  | !!!      | 46k          | 15.2M            | 2.29.1 (Oct 2020) |
+| [Luxon][2]     | 3.65 MB  | 20 KB    | 11.6k        | 1.8M             | 2.0.2 (Aug 2021)  |
+| [Date-FNS][3]  | 6.33 MB  | 18 KB    | 26.9k        | 10.9M            | 2.24.0 (Sep 2021) |
+| [Day.js][4]    | 623 KB   | 2 KB     | 36.3k        | 6.4M             | 1.10.7 (Sep 2021) |
+
+[0]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
+[1]: https://www.npmjs.com/package/moment
+[2]: https://www.npmjs.com/package/luxon
+[3]: https://www.npmjs.com/package/date-fns
+[4]: https://www.npmjs.com/package/dayjs

--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@ const moment = require('moment-timezone');
 const { format, utcToZonedTime, zonedTimeToUtc } = require('date-fns-tz');
 const { add, formatDistance, formatRelative } = require('date-fns');
 
+const dayjs = require('dayjs');
+var localizedFormat = require('dayjs/plugin/localizedFormat');
+var relativeTime = require('dayjs/plugin/relativeTime');
+var utc = require('dayjs/plugin/utc');
+var timezone = require('dayjs/plugin/timezone');
+
 // Simple test assert with a message
 function assert(message, condition, stack = false) {
 	if (condition) {
@@ -265,3 +271,46 @@ consola.info('Relative dates:', {
     relative: formatRelative(fnsDate30Days, fnsDate30Days),
     duration: formatDistance(fnsDate30Days, fnsDate),
 });
+
+/**
+ * Using Day.js
+ *
+ * Instead of modifying the native Date.prototype, Day.js creates a wrapper for the Date object. To get this wrapper object, simply call dayjs() with one of the supported input types.
+ *
+ * The Day.js object is immutable, that is, all API operations that change the Day.js object in some way will return a new instance of it.
+ *
+ * @link http://day.js.org/en/
+ */
+
+section('Using Day.js');
+
+const dayjsDate = dayjs(ISO8601_Date);
+dayjs.extend(localizedFormat);
+dayjs.extend(relativeTime);
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+consola.info('Parsed:', {
+    dayjsDate,
+    ISO: dayjsDate.toISOString(),
+});
+
+assert(
+    'Parsed ISO date should be the same timestamp as localized default',
+    +dayjsDate === +(DateTime.fromISO(ISO8601_Date)),
+);
+assert(
+    'Parsed ISO date should match input ISO date',
+    dayjsDate.toISOString() === ISO8601_Date,
+);
+assert(
+    `Default date format in ${timeZone} should be correct`,
+    dayjsDate.format('YYYY-MM-DD HH:mm:ss') === '2021-06-30 18:00:00',
+);
+
+consola.info(`Formatting examples for ${timeZone}:`, {
+    'String of Tokens':  dayjsDate.format('MMMM D, YYYY h:mm A'),
+    'LocalizedFormat Plugin': dayjsDate.format('L LT'),
+    'RelativeTime Plugin': dayjsDate.fromNow(),
+});
+

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const consola = require('consola');
 const { DateTime, Duration } = require('luxon')
 const moment = require('moment-timezone');
-const { format, utcToZonedTime } = require('date-fns-tz');
+const { format, utcToZonedTime, zonedTimeToUtc } = require('date-fns-tz');
 const { add, formatDistance, formatRelative } = require('date-fns');
 
 // Simple test assert with a message

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "consola": "^2.15.3",
     "date-fns": "^2.23.0",
     "date-fns-tz": "^1.1.6",
+    "dayjs": "^1.10.7",
     "luxon": "^2.0.2",
     "moment-timezone": "^0.5.33"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,11 @@ date-fns@^2.23.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
   integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
 
+dayjs@^1.10.7:
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
+  integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
+
 luxon@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.0.2.tgz#11f2cd4a11655fdf92e076b5782d7ede5bcdd133"


### PR DESCRIPTION
This pull request adds Day.js as a package for consideration alongside the existing contenders.

In addition, the README shows example usage of each package and how it handles basic date operations (parse, display, manipulate, query, etc.).